### PR TITLE
fix: sanitize filepath names

### DIFF
--- a/unzip.go
+++ b/unzip.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"io"
 	"fmt"
+	"strings"
 )
 
 type Unzip struct {
@@ -46,6 +47,9 @@ func (uz Unzip) Extract() error {
 		}()
 
 		path := filepath.Join(uz.Dest, f.Name)
+		if !strings.HasPrefix(path, filepath.Clean(uz.Dest)+string(os.PathSeparator)) {
+            return fmt.Errorf("%s: Illegal file path", path)
+        }
 
 		if f.FileInfo().IsDir() {
 			os.MkdirAll(path, f.Mode())


### PR DESCRIPTION
Prevent ZIP traversal by checking filepath names (https://github.com/snyk/zip-slip-vulnerability)

PoC to Test
```
package main

import (
    "./go-unzip"
	"fmt"
)
/ zip file can be taken from here: https://github.com/snyk/zip-slip-vulnerability/tree/master/archives
func main() {
	uz := unzip.New("/home/snoopy/ziptest/poc/ziptest2.zip", "/home/snoopy/zipper/uploads")
	err := uz.Extract()
	if err != nil {
		fmt.Println(err)
	}
}



```